### PR TITLE
Update truth-core documentation and spec kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ flowchart TD
 
 ---
 
+## 🧱 Модули (truth-core)
+
+- `core-lib` — модели и хранилище (SQLite), бизнес-логика, эксперты.
+- `api` — HTTP REST на базе Actix (`src/api.rs`), проверка подписей.
+- `p2p` — синхронизация узлов и обнаружение пиров (`src/p2p/*`).
+- `p2p/encryption` — Ed25519, подпись и верификация (`CryptoIdentity`).
+- `app/truthctl` — CLI для управления пирами и триггера синхронизации.
+
 ### Требования:
 - **Rust** ≥ 1.75
 - **cargo**
@@ -128,27 +136,24 @@ flowchart TD
 
 ## 🔧 Установка и сборка
 
-``bash
+```bash
 # Установка зависимостей
 sudo apt update && sudo apt install -y libsqlite3-dev pkg-config
 
-
-```bash
-# 1. Клонировать репозиторий
+# 1) Клонировать репозиторий
 git clone https://github.com/USERNAME/truth-training.git
 cd truth-training
 
-# Проверка
+# 2) Проверка и сборка
 cargo check
-
-# 2. Сборка
 cargo build --release
 
-# 3. Запуск
+# 3) Запуск (Actix HTTP + P2P)
 cargo run -- --port 8080 --db truth_training.db
-```
-# Запуск HTTP-сервера с синхронизацией
+
+# Альтернатива: запуск собранного бинарника
 ./target/release/truth_training --port 8080 --db truth_training.db
+```
 
 ---
 
@@ -198,6 +203,23 @@ curl -X POST http://127.0.0.1:8080/events   -H "Content-Type: application/json" 
 cargo run -- --port 8080 --db node1.db --http-addr http://127.0.0.1:8080
 cargo run -- --port 8081 --db node2.db --http-addr http://127.0.0.1:8081
 cargo run -- --port 8082 --db node3.db --http-addr http://127.0.0.1:8082
+```
+
+Настройка пиров и запуск синхронизации (`truthctl`):
+
+```bash
+# Добавляем пиров (используется файл peers.json в рабочей директории)
+truthctl peers add http://127.0.0.1:8081 <pubkey_hex_peer2>
+truthctl peers add http://127.0.0.1:8082 <pubkey_hex_peer3>
+
+# Просмотр списка
+truthctl peers list
+
+# Запуск синхронизации (push) со всеми пирами
+truthctl sync
+
+# Только pull с верификацией подписи и слиянием
+truthctl sync --pull-only
 ```
 ---
 
@@ -253,6 +275,22 @@ curl -X POST http://localhost:8080/detect     -H "Content-Type: application/json
 - `sync_request:{ts}` — для pull-запросов
 - `sync_push:{ts}` — для push (`/sync`)
 - `incremental_sync:{ts}` — для дельты
+
+Пример push-синхронизации:
+
+```bash
+TS=$(date +%s)
+PUB=<hex_pubkey>
+MSG="sync_push:${TS}"
+# Если в вашей сборке есть подпомощник, можно заменить SIG командой truthctl util sign
+SIG="<signature_hex>"
+curl -X POST http://localhost:8080/sync \
+  -H "Content-Type: application/json" \
+  -H "X-Public-Key: $PUB" \
+  -H "X-Signature: $SIG" \
+  -H "X-Timestamp: $TS" \
+  -d '{"events":[],"statements":[],"impacts":[],"metrics":[],"last_sync":0}'
+```
 
 ---
 
@@ -334,6 +372,8 @@ truthctl sync --pull-only
 
 Хранение пиров: `peers.json` в рабочей директории.
 
+Примечание: для работы `truthctl` локальная БД инициализируется автоматически; при `--verbose` выводится публичный ключ узла. Команды `peers add/list` и `sync` соответствуют потокам в `src/p2p/sync.rs`.
+
 ---
 
 ## 📦 Исторические команды CLI (устаревший режим)
@@ -361,6 +401,34 @@ CLI-команды **заменены API-вызовами**, т.к. проек�
 - управление выполняется через **HTTP API**.
 
 Для теста API можно использовать `curl` (см. раздел **API endpoints**).
+
+## 📱 Мобильные биндинги (FFI)
+Планируется FFI-слой (например, через `uniFFI`) для Android, позволяющий вызывать `truth-core` из Kotlin и использовать те же API/сущности. iOS рассматривается как следующий шаг.
+
+## 🔭 Диаграммы
+
+Диаграмма потоков данных синхронизации:
+
+```mermaid
+sequenceDiagram
+  participant A as Node A
+  participant B as Node B
+  A->>B: POST /sync (X-Public-Key, X-Signature, X-Timestamp)
+  B-->>A: 200 OK { SyncResult }
+  A->>B: POST /incremental_sync (delta)
+  B-->>A: 200 OK { SyncResult }
+```
+
+Диаграмма обнаружения пиров:
+
+```mermaid
+flowchart TD
+  A[Beacon Sender] -- UDP :37020 --> L[Local Network]
+  L --> B[Beacon Listener]
+  B -->|peer addr| P[Peer Registry peers.json]
+  P --> C[truthctl sync]
+  C -->|HTTP| S[Sync Engine]
+```
 
 ---
 

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -1,21 +1,25 @@
 ## Architecture Overview
 
-See `docs/architecture.md` for module layout and mermaid diagrams.
+This document reflects the current `truth-core` implementation and the CLI utilities.
 
-Core responsibilities
+Responsibilities
 - Data logic and storage (SQLite via rusqlite).
-- REST API (actix-web) for UI/peers.
-- P2P sync and discovery.
+- REST API (actix-web) for local UI and peer interop.
+- P2P synchronization and peer discovery.
+- Ed25519 signing/verification for sync endpoints.
 
 Modules
 - core-lib: models, storage (schema + ops), expert heuristics.
-- server (workspace root): API (`src/api.rs`), P2P sync (`src/p2p/*`), encryption (`src/p2p/encryption.rs`), HTTP server.
-- app: CLI tools — legacy demo and `truthctl` for peers and sync.
+- api: HTTP routes in `src/api.rs` (health, init/seed, events/statements, impacts, progress, get_data, sync, incremental_sync) with signature verification helpers.
+- p2p: sync flows and reconciliation in `src/p2p/sync.rs`, periodic node loop in `src/p2p/node.rs`.
+- p2p/encryption: `CryptoIdentity` (Ed25519) with hex helpers and Result-based verify; header message patterns.
+- net: UDP beacon sender/listener in `src/net.rs` for LAN peer discovery.
+- app/truthctl: peer registry (`peers.json`), `peers add/list`, and `sync` orchestration (push or pull-only).
 
 Non-goals (MVP)
-- Full reputation and Sybil-resistance; advanced propagation semantics.
+- Reputation/Sybil resistance; validator weighting; global propagation semantics.
 
-Mermaid overview
+Overview
 ```mermaid
 flowchart TD
   UI -->|HTTP| API
@@ -24,4 +28,5 @@ flowchart TD
   P2P --> ENC[CryptoIdentity]
   P2P --> NET[Discovery]
   ENC -->|sign/verify| P2P
+  CLI[truthctl] -->|peers.json| P2P
 ```

--- a/spec/05-api.md
+++ b/spec/05-api.md
@@ -30,3 +30,89 @@ Notes
 Future alignment
 - Consider consolidating GET /events and GET /get_data, and adding pagination.
 - Add OpenAPI in a follow-up.
+
+### JSON Schemas (informal)
+
+TruthEvent
+```json
+{
+  "id": 1,
+  "description": "string",
+  "context_id": 1,
+  "vector": true,
+  "detected": null,
+  "corrected": false,
+  "timestamp_start": 1710000000,
+  "timestamp_end": null,
+  "code": 1,
+  "signature": "hex|null",
+  "public_key": "hex|null"
+}
+```
+
+Statement
+```json
+{
+  "id": 1,
+  "event_id": 1,
+  "text": "string",
+  "context": "string|null",
+  "truth_score": 0.5,
+  "created_at": 1710000000,
+  "updated_at": 1710000000,
+  "signature": "hex|null",
+  "public_key": "hex|null"
+}
+```
+
+Impact
+```json
+{
+  "id": "uuid",
+  "event_id": "1",
+  "type_id": 1,
+  "value": true,
+  "notes": "string|null",
+  "created_at": 1710000000,
+  "signature": "hex|null",
+  "public_key": "hex|null"
+}
+```
+
+ProgressMetrics
+```json
+{
+  "id": 1,
+  "timestamp": 1710000000,
+  "total_events": 10,
+  "total_events_group": 10,
+  "total_positive_impact": 1.0,
+  "total_positive_impact_group": 1.0,
+  "total_negative_impact": 0.0,
+  "total_negative_impact_group": 0.0,
+  "trend": 1.0,
+  "trend_group": 1.0
+}
+```
+
+SyncData
+```json
+{
+  "events": [/* TruthEvent[] */],
+  "statements": [/* Statement[] */],
+  "impacts": [/* Impact[] */],
+  "metrics": [/* ProgressMetrics[] */],
+  "last_sync": 1710000000
+}
+```
+
+SyncResult
+```json
+{
+  "conflicts_resolved": 0,
+  "events_added": 0,
+  "statements_added": 0,
+  "impacts_added": 0,
+  "errors": ["string"]
+}
+```

--- a/spec/07-event-rating-protocol.md
+++ b/spec/07-event-rating-protocol.md
@@ -1,16 +1,19 @@
 ## Event Rating Protocol
 Source: docs/event_rating_protocol.md
 
-Status: Partially implemented.
-- Implemented: truth_events.code (u8) field; impacts storage; basic recalc metrics.
-- Implemented: optional per-record signatures (truth_events, statements, impact) with public_key for P2P verification.
+Status: MVP logic in place; full protocol pending.
+- Implemented (MVP):
+  - `truth_events.code` (u8) control/counter field.
+  - Optional per-record signatures (`truth_events`, `statements`, `impact`) for P2P verification.
+  - `statements.truth_score` optional per-statement scalar; `progress_metrics` aggregates via `/recalc`.
 - Missing (Next):
-  - Weighted scoring S_e from validator votes (require impact.user_id and weights).
+  - Weighted event score S_e from validator votes (requires `impact.user_id`, weights).
   - Reputation model (R_u, W_v) and threshold-based code transitions (T_up, T_down, T_confirm).
-  - Propagation counter semantics for 8-bit code; reset 01→00 signed by author.
-  - Persisted event_score and periodic recalc integration.
+  - Propagation counter semantics for 8-bit code; author-signed reset 01→00.
+  - Persisted `event_score` and periodic recalc integration.
 
 Action items
 - Extend schema: impact.user_id TEXT, optional truth_events.event_score REAL.
 - Implement recalc pipeline computing S_e and updating code + reputations.
 - Sync: include signatures and aggregate hints, resolve conflicts; ensure verification on ingress.
+ - Expose read-only score/progress via API; align UI.

--- a/spec/08-p2p-sync.md
+++ b/spec/08-p2p-sync.md
@@ -14,6 +14,10 @@ Security
   - `incremental_sync:{ts}` for POST /incremental_sync
 - Future: per-item signatures and validator identity on impacts.
 
+Header requirements
+- `/sync` and `/incremental_sync` MUST include `X-Timestamp`; the server reconstructs the canonical message string for verification.
+- `/get_data` is currently unauthenticated for LAN debug; do not expose publicly.
+
 Roadmap
 - Integrate conflict resolution into API/service layer.
 - Apply incoming payloads to DB; idempotency and upserts.

--- a/spec/09-ux-guidelines.md
+++ b/spec/09-ux-guidelines.md
@@ -6,3 +6,10 @@ Principles
 - No business logic in UI; use API/FFI.
 - Show expert wizard with questions and rationale.
 - Visualize progress trends; sync status.
+
+CLI UX (truthctl)
+- Subcommands mirror domain objects: `peers add/list`, `sync` (with `--pull-only`).
+- Consistent flags and defaults: `--db truth_db.sqlite`, `--peers peers.json`, `--verbose`.
+- Human-first output by default; JSON output can be added as a follow-up.
+- Avoid destructive actions; confirm before overwriting `peers.json`.
+- Align names with REST endpoints where possible; avoid inventing new terms.

--- a/spec/11-decision-log.md
+++ b/spec/11-decision-log.md
@@ -9,3 +9,9 @@ Summary (2025-10):
 - Migrated signature verification to Result-based API via `CryptoIdentity::verify_from_hex` with explicit error types.
 - Implemented async sync architecture with `/sync` and `/incremental_sync`, timestamped message patterns, and conflict resolution by latest timestamp.
 - Added `truthctl` CLI and file-based peer registry `peers.json` to manage peers and trigger syncs.
+
+Details
+- Verification now returns precise `VerifyError` variants (hex decode, parse, or verify failure), surfaced to 401 responses during development.
+- Both `/sync` and `/incremental_sync` require `X-Timestamp` and sign canonical strings `sync_push:{ts}` / `incremental_sync:{ts}`.
+- Reconciliation updates or inserts rows and logs actions; conflicts resolved by latest timestamp.
+- `truthctl` seeds the DB on first run and provides `peers add/list` and `sync` flows; it reuses the same `CryptoIdentity` signing logic as server codepaths.

--- a/spec/16-test-plan.md
+++ b/spec/16-test-plan.md
@@ -9,9 +9,17 @@
   - /impacts POST inserts row
   - /recalc inserts metrics row
   - /get_data returns arrays
+  - /sync with valid headers returns SyncResult; missing/invalid headers → 400/401
+  - /incremental_sync with valid headers returns SyncResult
 - Expert
   - evaluate_answers extremes produce +/-1 with confidence ~1
   - unknown answers reduce confidence
 - P2P
   - beacon sender/listener discover peers on localhost network
-  - sync_with_peer performs signed GET /get_data
+  - sync_with_peer performs GET /get_data (signed client-side), parses SyncData
+  - push_local_data posts signed /sync; reconcile merges data by timestamps
+  - incremental_sync_with_peer posts signed /incremental_sync with deltas
+
+Security
+- verify_signature success on correct message; failure on tampered message
+- consistent message construction for `sync_request`, `sync_push`, `incremental_sync`


### PR DESCRIPTION
Update README and Spec Kit documentation to accurately reflect the current `truth-core` architecture, API, and `truthctl` CLI tools.

---
<a href="https://cursor.com/background-agent?bcId=bc-88c2e0b4-80d7-4e60-b34e-c7f4467c371d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88c2e0b4-80d7-4e60-b34e-c7f4467c371d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

