### PR TITLE
Implement node and group trust rating system

### DIFF
--- a/core-lib/src/models.rs
+++ b/core-lib/src/models.rs
@@ -164,3 +164,46 @@ pub struct User {
     pub created_at: i64,
     pub last_sync: Option<i64>,
 }
+
+/// Рейтинг узла/ноды (node_id = публичный ключ в hex)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeRating {
+    pub node_id: String,
+    pub events_true: u32,
+    pub events_false: u32,
+    pub validations: u32,
+    pub reused_events: u32,
+    pub trust_score: f32, // -1.0 .. 1.0
+    pub last_updated: i64,
+}
+
+/// Рейтинг группы узлов
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupRating {
+    pub group_id: String,
+    pub members: Vec<String>,
+    pub avg_score: f32,
+    pub coherence: f32, // 0..1
+}
+
+/// Узел графа для визуализации
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphNode {
+    pub id: String,
+    pub score: f32,
+}
+
+/// Ребро графа между валидатором (source) и автором события (target)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphLink {
+    pub source: String,
+    pub target: String,
+    pub weight: f32, // 0..1
+}
+
+/// Данные графа доверия
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphData {
+    pub nodes: Vec<GraphNode>,
+    pub links: Vec<GraphLink>,
+}


### PR DESCRIPTION
Implement a node and group trust rating system to evaluate network contributions and enable trust graph visualization.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8aa0ab1-8b11-4c97-baf3-57b52cd85af6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8aa0ab1-8b11-4c97-baf3-57b52cd85af6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

